### PR TITLE
Process monitoring

### DIFF
--- a/monitor/Process-Monitor/Changelog
+++ b/monitor/Process-Monitor/Changelog
@@ -1,0 +1,20 @@
+Author: Alceu Rodrigues de Freitas Junior <arfreitas@cpan.org>
+Date:   Fri Apr 23 10:56:00 2017 -0300
+
+    Requested changes by preaction for Merge pull request
+
+
+commit 3fa5d7081bc42ed8e46ea47381ddcc78a5ef07d8
+Author: Alceu Rodrigues de Freitas Junior <arfreitas@cpan.org>
+Date:   Fri Apr 21 16:39:21 2017 -0300
+
+    Bugs fixes
+    
+    Added basic testing
+    Fixed bugs
+
+commit d07f849a7bb4870484374a3ac6c4a9582cc615a5
+Author: Alceu Rodrigues de Freitas Junior <arfreitas@cpan.org>
+Date:   Fri Apr 21 16:04:52 2017 -0300
+
+    Initial release

--- a/monitor/Process-Monitor/bin/procmon
+++ b/monitor/Process-Monitor/bin/procmon
@@ -1,0 +1,21 @@
+#!perl
+
+use warnings;
+use strict;
+use Process::Monitor qw(grab_procs);
+# VERSION
+
+# :TODO:21/04/2017 15:57:35:ARFREITAS: write proper command line parsing for arguments and doc
+#use GetOpt::Long;
+#use Pod::Usage
+
+my $data_ref = grab_procs(['www-data', 'barbie']);
+my $default_out = 'data.txt';
+open(my $out, '>>', $default_out) or die "Cannot create $default_out: $!";
+
+foreach my $row_ref(@{$data_ref}) {
+    print $out join('|', @{$row_ref}), "\n"; 
+}
+close($out);
+
+# vim: filetype=perl

--- a/monitor/Process-Monitor/dist.ini
+++ b/monitor/Process-Monitor/dist.ini
@@ -1,6 +1,6 @@
 name    = Process-Monitor
 author  = Alceu Rodrigues de Freitas Junior <arfreitas@cpan.org>
-license = GPL_3
+license = GPL_1
 copyright_holder = Alceu Rodrigues de Freitas Junior
 copyright_year   = 2017
 
@@ -14,16 +14,10 @@ version = 0.001
 [OurPkgVersion]
 [Test::Kwalitee]
 filename = xt/kwalitee.t
-[ChangelogFromGit]
-file_name = Changes
-max_age = 365
-tag_regexp = ^release-(\d+.*)$
-; authordep Dist::Zilla::Plugin::AutoPrereqs
-; authordep Dist::Zilla::Plugin::ChangelogFromGit
 ; authordep Dist::Zilla::Plugin::MetaResources
 ; authordep Dist::Zilla::Plugin::OurPkgVersion
 ; authordep Dist::Zilla::Plugin::Test::Kwalitee
 ; authordep Dist::Zilla::PluginBundle::Basic
-; authordep Software::License::GPL_3
+; authordep Software::License::GPL_1
 ; authordep Dist::Zilla::Plugin::MetaProvides
 ; authordep Dist::Zilla::Plugin::MetaJSON

--- a/monitor/Process-Monitor/dist.ini
+++ b/monitor/Process-Monitor/dist.ini
@@ -11,6 +11,13 @@ version = 0.001
 [AutoPrereqs]
 [MetaProvides::Package]
 [MetaJSON]
+[OurPkgVersion]
+[Test::Kwalitee]
+filename = xt/kwalitee.t
+[ChangelogFromGit]
+file_name = Changes
+max_age = 365
+tag_regexp = ^release-(\d+.*)$
 ; authordep Dist::Zilla::Plugin::AutoPrereqs
 ; authordep Dist::Zilla::Plugin::ChangelogFromGit
 ; authordep Dist::Zilla::Plugin::MetaResources

--- a/monitor/Process-Monitor/dist.ini
+++ b/monitor/Process-Monitor/dist.ini
@@ -1,0 +1,22 @@
+name    = Process-Monitor
+author  = Alceu Rodrigues de Freitas Junior <arfreitas@cpan.org>
+license = GPL_3
+copyright_holder = Alceu Rodrigues de Freitas Junior
+copyright_year   = 2017
+
+version = 0.001
+
+[@Basic]
+[CPANFile]
+[AutoPrereqs]
+[MetaProvides::Package]
+[MetaJSON]
+; authordep Dist::Zilla::Plugin::AutoPrereqs
+; authordep Dist::Zilla::Plugin::ChangelogFromGit
+; authordep Dist::Zilla::Plugin::MetaResources
+; authordep Dist::Zilla::Plugin::OurPkgVersion
+; authordep Dist::Zilla::Plugin::Test::Kwalitee
+; authordep Dist::Zilla::PluginBundle::Basic
+; authordep Software::License::GPL_3
+; authordep Dist::Zilla::Plugin::MetaProvides
+; authordep Dist::Zilla::Plugin::MetaJSON

--- a/monitor/Process-Monitor/lib/Process/Monitor.pm
+++ b/monitor/Process-Monitor/lib/Process/Monitor.pm
@@ -2,7 +2,7 @@ package Process::Monitor;
 use strict;
 use warnings;
 use Proc::ProcessTable 0.53;
-use List::MoreUtils 0.416;
+use List::MoreUtils 0.416 'any';
 use Exporter 'import';
 
 # VERSION
@@ -75,7 +75,7 @@ Except for the first two indexes, all other items are described in the L<Proc::P
 sub grab_procs {
 
     my ($user_list_ref) = @_;
-    my $procs = Pro::ProcessTable->new();
+    my $procs = Proc::ProcessTable->new();
     my %users_map;
 
     foreach my $user ( @{$user_list_ref} ) {
@@ -86,7 +86,7 @@ sub grab_procs {
     my @data;
     my $now = time();
 
-    foreach my $p ( $procs->table() ) {
+    foreach my $p ( @{$procs->table()} ) {
 
         if ( any { $p->uid == $_ } keys(%users_map) ) {
             my $pctcpu = ( $p->pctcpu ) + 0;

--- a/monitor/Process-Monitor/lib/Process/Monitor.pm
+++ b/monitor/Process-Monitor/lib/Process/Monitor.pm
@@ -1,0 +1,150 @@
+package Process::Monitor;
+use strict;
+use warnings;
+use Proc::ProcessTable 0.53;
+use List::MoreUtils 0.416;
+use Exporter 'import';
+
+# VERSION
+
+our @EXPORT_OK = qw(grab_procs);
+
+=pod
+
+=head1 NAME
+
+Process::Monitor - search for specific user's process, collecting CPU and memory used, among other things
+
+=head1 DESCRIPTION
+
+This module provides a C<sub> to retrieve process information from specific users.
+
+=head1 EXPORTS
+
+The following functions are exported by demand:
+
+=head2 grab_procs
+
+Expects as parameters an array reference containing the list of corresponding logins of the users.
+
+Returns an array reference, where each row is itself an array reference with the following 
+content (in that specific order):
+
+=over
+
+=item *
+
+The UNIX epoch time when this function was invoked. Useful to aggregate the data.
+
+=item *
+
+The associated user login.
+
+=item *
+
+pid
+
+=item *
+
+pctcpu
+
+=item *
+
+rss
+
+=item *
+
+state
+
+=item *
+
+start
+
+=item *
+
+cmndline
+
+=back
+
+per process that was created by the given users logins (UID, not effective UID).
+
+Except for the first two indexes, all other items are described in the L<Proc::ProcessTable::Process> Pod.
+
+=cut
+
+sub grab_procs {
+
+    my ($user_list_ref) = @_;
+    my $procs = Pro::ProcessTable->new();
+    my %users_map;
+
+    foreach my $user ( @{$user_list_ref} ) {
+        my $uid = getpwnam($user);
+        $users_map{$uid} = $user;
+    }
+
+    my @data;
+    my $now = time();
+
+    foreach my $p ( $procs->table() ) {
+
+        if ( any { $p->uid == $_ } keys(%users_map) ) {
+            my $pctcpu = ( $p->pctcpu ) + 0;
+            push(
+                @data,
+                [
+                    (
+                        $now,      $users_map{ $p->uid },
+                        $p->pid,   $pctcpu,
+                        $p->rss,   $p->state,
+                        $p->start, $p->cmndline
+                    )
+
+                ]
+            );
+        }
+
+    }
+
+    return \@data;
+
+}
+
+=pod
+
+=head1 SEE ALSO
+
+=over
+
+=item *
+
+L<Proc::ProcessTable>
+
+=back
+
+=head1 AUTHOR
+
+Alceu Rodrigues de Freitas Junior, E<lt>arfreitas@cpan.orgE<gt>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2015 of Alceu Rodrigues de Freitas Junior, E<lt>arfreitas@cpan.orgE<gt>
+
+This file is part of Process Monitor project.
+
+Process Monitor is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Process Monitor is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Linux Info.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut
+
+1;

--- a/monitor/Process-Monitor/lib/Process/Monitor.pm
+++ b/monitor/Process-Monitor/lib/Process/Monitor.pm
@@ -2,7 +2,7 @@ package Process::Monitor;
 use strict;
 use warnings;
 use Proc::ProcessTable 0.53;
-use List::MoreUtils 0.416 'any';
+use List::Util 1.33 'any';
 use Exporter 'import';
 
 # VERSION

--- a/monitor/Process-Monitor/t/1-basic.t
+++ b/monitor/Process-Monitor/t/1-basic.t
@@ -1,0 +1,19 @@
+use warnings;
+use strict;
+use Test::More;
+
+BEGIN {
+    use_ok( 'Process::Monitor', qw(grab_procs) );
+}
+
+ok( grab_procs( ['root'] ), 'grab_procs works' );
+my $data_ref = grab_procs( ['root'] );
+is( ref($data_ref), 'ARRAY' );
+
+foreach my $row_ref ( @{$data_ref} ) {
+    is( ref($row_ref), 'ARRAY' );
+}
+
+done_testing;
+
+# vim: filetype=perl

--- a/monitor/Process-Monitor/xt/pod-coverage.t
+++ b/monitor/Process-Monitor/xt/pod-coverage.t
@@ -1,0 +1,35 @@
+use warnings;
+use strict;
+use Test::More;
+use Config;
+
+eval "use Test::Pod::Coverage 1.00";
+plan skip_all => "Test::Pod::Coverage 1.00 required for testing POD coverage"
+  if $@;
+
+my @modules;
+
+if ( $Config{useithreads} ) {
+
+    @modules = all_modules();
+
+}
+else {
+
+    my @tmp = all_modules();
+
+    foreach my $mod (@tmp) {
+
+        push( @modules, $mod ) unless ( $mod eq 'Term::YAP::iThread' );
+
+    }
+
+}
+
+foreach my $module (@modules) {
+
+    pod_coverage_ok( $module, 'Pod coverage is ok' );
+
+}
+
+done_testing();

--- a/monitor/Process-Monitor/xt/pod.t
+++ b/monitor/Process-Monitor/xt/pod.t
@@ -1,0 +1,5 @@
+use Test::More;
+eval "use Test::Pod 1.00";
+plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;
+all_pod_files_ok();
+


### PR DESCRIPTION
Simple script to grab information from running process.
Those processes will be filtered by login, and currently a CSV file is generated as output.
Data is still raw (no grouping, no aggregation). I'm still not sure how we want to do that. Some possibilities is to get average and standard deviation, but we should find out if we should group by login and/or process command line (the program that is running).
Collectd has a Perl plugin that could be used to run this script and collect the info, to send to the monitoring host, but this is still to be developed. For now, using crontab would be enough for that, and I'm not sure either we should capture this information long periods.
After all, we are looking for bottlenecks on the whole process. It might be possible we shut it down after some iterations.